### PR TITLE
Update module name in documentation

### DIFF
--- a/docs/Control/Timer.md
+++ b/docs/Control/Timer.md
@@ -1,4 +1,4 @@
-## Module Control.Timer
+## Module DOM.Timer
 
 ## Exaple
 ```purescript
@@ -7,7 +7,7 @@ module Main where
 import Prelude
 import Control.Monad.Eff (Eff())
 import Control.Monad.Eff.Console (print, CONSOLE())
-import Control.Timer
+import DOM.Timer
 
 main :: forall eff. Eff (console :: CONSOLE, timer :: Timer | eff) Unit
 main = do


### PR DESCRIPTION
`Control.Timer` didn't work for me when I followed this documentation. So I changed to `DOM.Timer` like it was in the code and it worked. I assume the code is correct and the documentation is behind?